### PR TITLE
Tom merge game to room

### DIFF
--- a/screens/clikBait.js
+++ b/screens/clikBait.js
@@ -22,10 +22,11 @@ export default function ClikBait(props) {
     db.database().ref(`/Rooms/${roomName}/Game/Scores`)
   );
 
-  //TODO i removed the below, as i decided it makes more sense to push your player data onto the scoreboard when you're in the waiting room. was having difficulties when we did it on here.
-  // useEffect(() => {
-  //   allScores && allScores.update({ Scores: { [uid]: 0 } });
-  // }, []);
+  //TODO This can be removed if we want to keep score handling on the waiting room
+  useEffect(() => {
+    const playerData = db.database().ref(`/Rooms/${roomName}/Game/Scores/`);
+    playerData.update({ [uid]: 0 });
+  }, []);
 
   //TODO look into refactoring, maybe remove useEffect
   //TODO clean up game object when done

--- a/screens/waitingRoom.js
+++ b/screens/waitingRoom.js
@@ -60,12 +60,12 @@ export default function WaitingRoom(props) {
     gameName &&
       db.database().ref(`/Rooms/${roomName}/Game`).update({ Name: gameName });
 
-    //added scoreboard creation on here, as i was having difficulty placing it in within clikBait
-    uid &&
-      db
-        .database()
-        .ref(`/Rooms/${roomName}/Game/Scores`)
-        .update({ [uid]: 0 });
+    //TODO i added the scoreboard functionality on here. I decided to undo it as it does make more sense to add the scores based on the game. What if snake doesn't use scores? it is here though in case somebody decided to go that route.
+    // uid &&
+    //   db
+    //     .database()
+    //     .ref(`/Rooms/${roomName}/Game/Scores`)
+    //     .update({ [uid]: 0 });
 
     uid &&
       db


### PR DESCRIPTION
I changed a bunch of stuff.

I moved some game-ready functionality away from clikBait and put it on the waiting room.

1. Waiting room now creates the Game object, which houses the gameName (comes from the game selector as props), the scoreboard, and gameRules
2. Somewhat changed GamesList schema; right now it only holds a rules object, which can include starting board and other rules. Gets cloned onto the Room object when waiting room is created
3. Once game is over, leaving the room via the cleanUp function removes your UID from the playerList (doesn't effect score outcomes of game, so that might be useful for later when we want to keep scores. When there is no UIDs left in playerList, the room gets deleted.

Depending on how far you are on creating your games, you may need to change certain references to firebase and whatnot.

I'm opening this up to the team to review before merging into master, as i want to make sure everyone understands some of the changes i made.

I closed the previous request as i went back on a change; i changed the code so waiting room handled the scoreboard creation, but i decided its probably for the best for each game to control that, as some may have different scoring systems or win conditions. I didn't want to force a game like tic-tac-toe to have a score system.


NEW SCHEMA: